### PR TITLE
Add general-purpose logger module

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ Project Organization
     │                         generated with `pip freeze > requirements.txt`
     │
     ├── setup.py           <- makes project pip installable (pip install -e .) so src can be imported
+
+
+Logging
+-------
+
+This project provides a general-purpose logger utility in `src/utils/logger.py`.
+
+**Usage Example:**
+
+```python
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+logger.info("This is an info message.")
+logger.error("This is an error message.")
+```
+
+You can attach this logger to any module or script in the project.
     └── src                <- Source code for use in this project.
         ├── __init__.py    <- Makes src a Python module
         │

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -16,8 +16,7 @@ def get_logger(name: Optional[str] = None, level: int = logging.INFO) -> logging
     if not logger.handlers:
         handler = logging.StreamHandler(sys.stdout)
         formatter = logging.Formatter(
-            "[%(asctime)s] %(levelname)s %(name)s: %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S"
+            "[%(asctime)s] %(levelname)s %(name)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
         )
         handler.setFormatter(formatter)
         logger.addHandler(handler)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -16,7 +16,8 @@ def get_logger(name: Optional[str] = None, level: int = logging.INFO) -> logging
     if not logger.handlers:
         handler = logging.StreamHandler(sys.stdout)
         formatter = logging.Formatter(
-            "[%(asctime)s] %(levelname)s %(name)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+            "[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S"
         )
         handler.setFormatter(formatter)
         logger.addHandler(handler)


### PR DESCRIPTION
This PR adds a reusable logger utility in src/utils/logger.py and updates the README with usage instructions. The logger can be attached to any module in the project for consistent logging.\n\nCloses #6.